### PR TITLE
Add space for AXI Frontline Debrief

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const db = require('./db/index');
 const zmq = require("zeromq");
 const zlib = require("zlib");
 const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
 
 const PORT = process.env.PORT; // Port to open website on (https://localhost:<PORT>)
 const WEBAPPMODE = process.env.WEBAPPMODE; // Set to DEV to disable HTTPS forwarding
@@ -44,10 +46,11 @@ function requireHTTPS(req, res, next) {
 }
 
 app.use(requireHTTPS);
-app.use(cors())
+app.use(cors());
+const pageDirectory = path.join(__dirname, 'public');
 
 app.get('/', function (req,res) {
-    res.sendFile(__dirname + '/public/index.html');
+    res.sendFile(path.join(pageDirectory, 'index.html'));
 });
 
 app.use(express.static('public'));
@@ -83,23 +86,23 @@ app.get('/api/club10', async function(req, res) {
 );
 
 app.get('/api', function (req,res) {
-    res.sendFile(__dirname + '/public/api.html');
+    res.sendFile(path.join(pageDirectory, 'api.html'));
 });
 
 app.get('/watch', function (req,res) {
-    res.sendFile(__dirname + '/public/watch.html');
+    res.sendFile(path.join(pageDirectory, 'watch.html'));
 });
 
 app.get('/leaderboards', function (req,res) {
-    res.sendFile(__dirname + '/public/leaderboards.html');
+    res.sendFile(path.join(pageDirectory, 'leaderboards.html'));
 });
 
 app.get('/club10', function (req,res) {
-    res.sendFile(__dirname + '/public/club10.html');
+    res.sendFile(path.join(pageDirectory, 'club10.html'));
 });
 
 app.get('/ranks', function (req,res) {
-    res.sendFile(__dirname + '/public/ranks.html');
+    res.sendFile(path.join(pageDirectory, 'ranks.html'));
 });
 
 app.get('/wiki', function (req,res) {
@@ -112,6 +115,17 @@ app.get('/news/ea-buys-frontier-ip', function (req,res) {
 
 app.get('/healthcheckstatus', function (req,res) {
     res.status(200).send('This website is running! 😊');
+});
+
+app.get('/frontlinedebrief/:filename', (req, res) => {
+  const { filename } = req.params;
+  const filePath = path.join(pageDirectory, 'frontlinedebrief', filename + '.html');
+
+  if (fs.existsSync(filePath)) {
+    res.sendFile(filePath);
+  } else {
+    res.sendFile(path.join(pageDirectory, 'index.html'), 404);
+  }
 });
 
 app.get('*', function(req, res){

--- a/public/frontlinedebrief/29-5-2023.html
+++ b/public/frontlinedebrief/29-5-2023.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>AXI Frontline Debrief</title>
+    <meta name="description" content="The Anti-Xeno Initiative, an Elite:Dangerous player group dedicated to the defense of humanity."/>
+    <meta name="theme-color" content="#000000"/>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:title" content="The Anti-Xeno Initiative" />
+    <meta property="og:description" content="The Anti-Xeno Initiative, an Elite:Dangerous player group dedicated to the defense of humanity." />
+    <meta property="og:image" content="https://axicloud.blob.core.windows.net/public/images/AXI_Insignia_Hypen_128.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
+    <link rel="manifest" href="/images/site.webmanifest">
+    <link rel="stylesheet" href="/styles/common.css">
+    <link rel="stylesheet" href="/styles/home.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/@mdi/font@6.5.95/css/materialdesignicons.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Lexend&family=Outfit:wght@400;600&family=Roboto&display=swap');
+    </style>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap');
+    </style>       
+</head>
+<body style="position: relative;">
+    <div class="background"></div>
+    <div class="page">
+        <div style="width: 100%;">
+            <nav>
+                <nav role="navigation" class="showinmobile">
+                    <div id="menuToggle">
+                      <!--
+                      A fake / hidden checkbox is used as click reciever,
+                      so you can use the :checked selector on it.
+                      -->
+                      <input type="checkbox" />
+                      
+                      <!--
+                      Some spans to act as a hamburger.
+                      
+                      They are acting like a real hamburger,
+                      not that McDonalds stuff.
+                      -->
+                      <span></span>
+                      <span></span>
+                      <span></span>
+                      
+                      <!--
+                      Too bad the menu has to be inside of the button
+                      but hey, it's pure CSS magic.
+                      -->
+                      <ul id="menu">
+                        <a href="/"><li>Home</li></a>
+                        <a href="/watch"><li>Activity</li></a>
+                        <a href="/leaderboards"><li>Leaderboards</li></a>
+                        <a href="/ranks"><li>Ranks</li></a>
+                        <a href="https://wiki.antixenoinitiative.com"><li>Wiki</li></a>
+                        <a href="https://store.antixenoinitiative.com/"><li>Merch</li></a>
+                        <a href="https://discord.gg/bqmDxdm"><li>Discord</li></a>
+                      </ul>
+                    </div>
+                </nav>
+                <div class="nav-left">
+                    <img src="https://axicloud.blob.core.windows.net/public/images/AXI_Insignia_Hypen_128.png" alt="Anti-Xeno Initiative Logo">
+                    <div class="title noselect">Anti-Xeno Initiative</div>
+                </div>
+                <div class="nav-mid mobile-hide">
+                    <a href="/">Home</a>
+                    <a href="/watch">Activity</a>
+                    <a href="/leaderboards">Leaderboards</a>
+                    <a href="/ranks">Ranks</a>
+                    <a href="https://wiki.antixenoinitiative.com">Wiki</a>
+                    <a href="https://store.antixenoinitiative.com/">Merch</a>
+                    <a href="https://sites.google.com/view/the-anti-xeno-initiative/home">Old Site</a>
+                </div>
+                <div class="nav-right mobile-hide">
+                    <a class="link" href="https://discord.gg/bqmDxdm"><span class="mdi mdi-discord"> </span>Discord</a>
+                </div>
+            </nav>
+        </div>
+        <div class="content">
+            <div class="flex-column max-width gap-large">
+                <header class="">
+                    <h1><span>Anti-Xeno Initiative</span><br>Frontline Debrief: 28-5-3309</h1>
+                </header>
+                    <section class="news smallround grow">
+                        <h2>Introduction</h2>
+                        <div class="article-content">
+                            Welcome, Commanders, to the first publication of the Anti-Xeno Initiative's Frontline Debrief! Inspired by CMDR Avasa Siuu's old weekly video debriefs, I, CMDR Airom42, will bring you a summary of the newest and most important news from the Thargoid War each week. This will strive to be as comprehensive and informative as possible, aimed at those who want to stay informed about the newest technology, tactics, and tales from the front in the past week. This will generally be finished by a few days after Thargsday, striving to bring the freshest information as fast as possible.
+                        </div>
+                    </section>
+                    <section class="news smallround grow">
+                        <h2>This Week in the Galaxy</h2>
+                        <h3>New Tech - Pulse Wave Xeno Scanner</h3>
+                        <div class="article-content">
+                            <p>
+                                In collaboration with Professor Ishmael Palin, Aegis has developed a new scanner capable of revealing points of interest on a Thargoid Titan's hull. This module works as a hybrid of the Pulse Wave Analyzer and a regular Xeno Scanner, allowing CMDRs to scan smaller thargoid craft and reveal points on the Titan to which a research limpet can be attached.
+                                Although a community goal to unlock the module is ongoing, there was a brief period on Friday when the scanner could be purchased. With the completion of the CG, the module will be made available to all CMDRs at all Resue Megaships and will be purchasable with credits.
+                            </p>
+                        </div>
+                        <h3>Community Goals</h3>
+                        <div class="article-content">
+                            There are two community goals active this week, relating to the new xeno scanner. As is routine, there is a delivery CG and a combat CG to protect the deliveries. This CG will establish Pulse Wave Xeno Scanner availability at all rescue megaships, and grant a free module to the top 25% of contributors in each CG. This CG is run out of Muller Terminal in the Rabh system.
+                            <a class="link" href="https://inara.cz/elite/communitygoals/">View on Inara</a>
+                        </div>
+                    </section>
+                    <section class="news smallround grow">
+                        <h2>Tales From the Front</h2>
+                        <h3>Into the Maw</h3>
+                        <div class="article-content">
+                            With the early release of the new pulse scanner module, many CMDRs have already begun to analyze Titan’s hull. The scanner has revealed various points of interest to which a research limpet can be docked, allowing for samples to be extracted from the Titan's Hull and Maw. 
+                            CMDR Mechan has done some recon and released a short video of the capabilities of the Pulse Wave Xeno Scanner, and the variety of samples that can be obtained from the Titans.
+                            <div class="video-container">
+                                <iframe class="video" src="https://www.youtube.com//embed/-Xt-cbiYdv0" allowfullscreen></iframe>
+                            </div>
+                        </div>
+                        <h3>The Ongoing War</h3>
+                        <div class="article-content">
+                            A record-breaking 59 systems were cleared of Thargoid influence last week. As we enter the war’s 26th week, this is a major victory in stemming the Thargoid expansion. So far this week, over a dozen systems have been cleared, representing efforts mainly in the Raijin and Indra maelstrom regions.
+                            <a class="link" href="https://dcoh.watch/systems">View DCoH Overview</a>
+                        </div>
+                    </section>
+                    <section class="news smallround grow">
+                        <h2>The Wrong Kind of Bugs</h3>
+                            <div class="article-content">
+                                As always, everyone's least favorite AX topic: the kind of bug we can’t kill with Gauss. With update 15.1, we saw some issues fixed but a few new ones popped up. Please take a minute to either confirm or upvote the following issues:
+                                <ul>
+                                    <li>Exerted hearts not glowing properly: <a href="https://issues.frontierstore.net/issue-detail/59507">https://issues.frontierstore.net/issue-detail/59507</a></li>
+                                    <li>No shutdown pulse warning when Thargoids wake in: <a href="https://issues.frontierstore.net/issue-detail/59432">https://issues.frontierstore.net/issue-detail/59432</a></li>
+                                </ul>
+                            </div>
+                        </section>
+                <section class="about smallround grow">
+                    <div class="max-text">
+                        <p>The Anti-Xeno Initiative <span class="axiorange">Frontline Debrief</span> is a weekly post about what has happened in Anti-Xeno news in the past week. It is maintained primarily by <span class="axiorange">CMDR Airom42</span>, and supported by the efforts of many other AXI CMDRs.</p>
+                        <p>Special thanks to CMDRs Mechan and Sirruf for help with this week's issue.</p>
+                    </div>
+                </section>
+                <section class="footer smallround grow">
+                    <img src="https://axicloud.blob.core.windows.net/public/images/AXI_Insignia_Hypen_128.png" alt="">
+                    <p>Site content copyright © 2023, The Anti-Xeno Initiative. All Rights Reserved. Elite Dangerous and all related marks are trademarks of Frontier Developments Inc.</p>
+                </section>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/public/frontlinedebrief/29-5-2023.html
+++ b/public/frontlinedebrief/29-5-2023.html
@@ -89,21 +89,19 @@
                     <section class="news smallround grow">
                         <h2>Introduction</h2>
                         <div class="article-content">
-                            Welcome, Commanders, to the first publication of the Anti-Xeno Initiative's Frontline Debrief! Inspired by CMDR Avasa Siuu's old weekly video debriefs, I, CMDR Airom42, will bring you a summary of the newest and most important news from the Thargoid War each week. This will strive to be as comprehensive and informative as possible, aimed at those who want to stay informed about the newest technology, tactics, and tales from the front in the past week. This will generally be finished by a few days after Thargsday, striving to bring the freshest information as fast as possible.
-                        </div>
-                    </section>
+                            <p>Welcome, Commanders, to the first publication of the Anti-Xeno Initiative's Frontline Debrief! Inspired by CMDR Avasa Siuu's old weekly video debriefs, I, CMDR Airom42, will bring you a summary of the newest and most important news from the Thargoid War each week. This will strive to be as comprehensive and informative as possible, aimed at those who want to stay informed about the newest technology, tactics, and tales from the front in the past week. This will generally be finished by a few days after Thargsday, striving to bring the freshest information as fast as possible.</p>
+                            </div>
+                        </section>
                     <section class="news smallround grow">
                         <h2>This Week in the Galaxy</h2>
                         <h3>New Tech - Pulse Wave Xeno Scanner</h3>
                         <div class="article-content">
-                            <p>
-                                In collaboration with Professor Ishmael Palin, Aegis has developed a new scanner capable of revealing points of interest on a Thargoid Titan's hull. This module works as a hybrid of the Pulse Wave Analyzer and a regular Xeno Scanner, allowing CMDRs to scan smaller thargoid craft and reveal points on the Titan to which a research limpet can be attached.
-                                Although a community goal to unlock the module is ongoing, there was a brief period on Friday when the scanner could be purchased. With the completion of the CG, the module will be made available to all CMDRs at all Resue Megaships and will be purchasable with credits.
-                            </p>
+                            <p>In collaboration with Professor Ishmael Palin, Aegis has developed a new scanner capable of revealing points of interest on a Thargoid Titan's hull. This module works as a hybrid of the Pulse Wave Analyzer and a regular Xeno Scanner, allowing CMDRs to scan smaller Thargoid craft and reveal points on the Titan to which a research limpet can be attached.</p>
+                            <p>Although a community goal to unlock the module is ongoing, there was a brief period on Friday when the scanner could be purchased. With the completion of the CG, the module will be made available to all CMDRs at all Rescue Megaships and will be purchasable with credits.</p>
                         </div>
                         <h3>Community Goals</h3>
                         <div class="article-content">
-                            There are two community goals active this week, relating to the new xeno scanner. As is routine, there is a delivery CG and a combat CG to protect the deliveries. This CG will establish Pulse Wave Xeno Scanner availability at all rescue megaships, and grant a free module to the top 25% of contributors in each CG. This CG is run out of Muller Terminal in the Rabh system.
+                            <p>There are two community goals active this week, relating to the new <span class="axiorange">Pulse Wave Xeno Scanner</span>. As is routine, there is a delivery CG and a combat CG to protect the deliveries. This CG will establish Pulse Wave Xeno Scanner availability at all rescue megaships, and grant a free module to the top 25% of contributors in each CG. This CG is run out of Muller Terminal in the Rabh system.</p>
                             <a class="link" href="https://inara.cz/elite/communitygoals/">View on Inara</a>
                         </div>
                     </section>
@@ -111,26 +109,27 @@
                         <h2>Tales From the Front</h2>
                         <h3>Into the Maw</h3>
                         <div class="article-content">
-                            With the early release of the new pulse scanner module, many CMDRs have already begun to analyze Titan’s hull. The scanner has revealed various points of interest to which a research limpet can be docked, allowing for samples to be extracted from the Titan's Hull and Maw. 
-                            CMDR Mechan has done some recon and released a short video of the capabilities of the Pulse Wave Xeno Scanner, and the variety of samples that can be obtained from the Titans.
+                            <p>With the early release of the new pulse scanner module, many CMDRs have already begun to analyze Titan’s hull. The scanner has revealed various points of interest to which a research limpet can be docked, allowing for samples to be extracted from the Titan's Hull and Maw.</p>
+                            <p>CMDR Mechan has done some recon and released a short video of the capabilities of the Pulse Wave Xeno Scanner, and the variety of samples that can be obtained from the Titans.</p>
                             <div class="video-container">
                                 <iframe class="video" src="https://www.youtube.com//embed/-Xt-cbiYdv0" allowfullscreen></iframe>
                             </div>
                         </div>
                         <h3>The Ongoing War</h3>
                         <div class="article-content">
-                            A record-breaking 59 systems were cleared of Thargoid influence last week. As we enter the war’s 26th week, this is a major victory in stemming the Thargoid expansion. So far this week, over a dozen systems have been cleared, representing efforts mainly in the Raijin and Indra maelstrom regions.
+                            <p>A <span class="axiorange">record-breaking 59 systems</span> were cleared of Thargoid influence last week. This means that for only the second time, the number of systems under Thargoid influence decreased. As we enter the war’s 26th week, this is a major victory in stemming the Thargoid expansion.</p>
+                            <p>So far this week, over a dozen systems have been cleared, representing efforts mainly in the Raijin and Indra maelstrom regions. However, with 40 new alerts, 7 new invasions, and 15 systems falling under Thargoid control, there is still much to be done in combatting the Thargoid advance.</p>
                             <a class="link" href="https://dcoh.watch/systems">View DCoH Overview</a>
                         </div>
                     </section>
                     <section class="news smallround grow">
                         <h2>The Wrong Kind of Bugs</h3>
                             <div class="article-content">
-                                As always, everyone's least favorite AX topic: the kind of bug we can’t kill with Gauss. With update 15.1, we saw some issues fixed but a few new ones popped up. Please take a minute to either confirm or upvote the following issues:
+                                <p>As always, everyone's least favorite AX topic: the kind of bug we can’t kill with Gauss. With update 15.1, we saw some issues fixed but a few new ones popped up. Please take a minute to either confirm or upvote the following issues:
                                 <ul>
                                     <li>Exerted hearts not glowing properly: <a href="https://issues.frontierstore.net/issue-detail/59507">https://issues.frontierstore.net/issue-detail/59507</a></li>
                                     <li>No shutdown pulse warning when Thargoids wake in: <a href="https://issues.frontierstore.net/issue-detail/59432">https://issues.frontierstore.net/issue-detail/59432</a></li>
-                                </ul>
+                                </ul></p>
                             </div>
                         </section>
                 <section class="about smallround grow">

--- a/public/frontlinedebrief/issue1.html
+++ b/public/frontlinedebrief/issue1.html
@@ -84,7 +84,7 @@
         <div class="content">
             <div class="flex-column max-width gap-large">
                 <header class="">
-                    <h1><span>Anti-Xeno Initiative</span><br>Frontline Debrief: 28-5-3309</h1>
+                    <h1><span>Anti-Xeno Initiative</span><br>Frontline Debrief: 29-5-3309</h1>
                 </header>
                     <section class="news smallround grow">
                         <h2>Introduction</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -92,9 +92,9 @@
                 <div class="flex-row adaptive-row gap-large">
                     <section class="news smallround grow">
                         <h2>News</h2>
-                        <a class="noDecoration" href="\frontlinedebrief\29-5-2023">
+                        <a href="\frontlinedebrief\29-5-2023">
                             <article class="smallround">
-                                <div class="article-title" style="background-position: center top -20px; background-image: linear-gradient(90deg, rgba(19,19,19,1) 0%, rgba(19,19,19,0) 100%), url(https://cdn.discordapp.com/attachments/821360846373912646/1112525436925263922/titanblur.jpg);">
+                                <div class="article-title" style="background-image: linear-gradient(90deg, rgba(19,19,19,1) 0%, rgba(19,19,19,0) 100%), url(https://cdn.discordapp.com/attachments/821360846373912646/1112525436925263922/titanblur.jpg);">
                                     <h3>Anti-Xeno Initiative Frontline Debrief</h3>
                                     <div>May 29th 3309</div>
                                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -92,7 +92,7 @@
                 <div class="flex-row adaptive-row gap-large">
                     <section class="news smallround grow">
                         <h2>News</h2>
-                        <a href="\frontlinedebrief\29-5-2023">
+                        <a href="\frontlinedebrief\issue1">
                             <article class="smallround">
                                 <div class="article-title" style="background-image: linear-gradient(90deg, rgba(19,19,19,1) 0%, rgba(19,19,19,0) 100%), url(https://cdn.discordapp.com/attachments/821360846373912646/1112525436925263922/titanblur.jpg);">
                                     <h3>Anti-Xeno Initiative Frontline Debrief</h3>

--- a/public/index.html
+++ b/public/index.html
@@ -92,6 +92,22 @@
                 <div class="flex-row adaptive-row gap-large">
                     <section class="news smallround grow">
                         <h2>News</h2>
+                        <a class="noDecoration" href="\frontlinedebrief\29-5-2023">
+                            <article class="smallround">
+                                <div class="article-title" style="background-position: center top -20px; background-image: linear-gradient(90deg, rgba(19,19,19,1) 0%, rgba(19,19,19,0) 100%), url(https://cdn.discordapp.com/attachments/821360846373912646/1112525436925263922/titanblur.jpg);">
+                                    <h3>Anti-Xeno Initiative Frontline Debrief</h3>
+                                    <div>May 29th 3309</div>
+                                </div>
+                                <div class="article-content">
+                                    <p>Hot off the presses of Ceres Tarn, CMDR Airom42 brings you the first issue of AXI's Frontline Debrief.<br><br>
+                                        
+                                        This weekly publication aims to bring you a summary of the newest and most important news from the Thargoid War each week.<br><br>
+                                        
+                                        This week, we will be covering the new Pulse Wave Xeno Scanner, as well as more information on the Thargoid Titans.</p>
+                                        <p>Special thanks to CMDR Mechan for his informative video on the capabilities of the new scanner module.</p>
+                                    </div>
+                            </article>
+                        </a>
                         <article class="smallround">
                             <div class="article-title" style="background-image: linear-gradient(90deg, rgba(19,19,19,1) 0%, rgba(19,19,19,0) 100%), url(https://axicloud.blob.core.windows.net/public/images/challenger-wide.png);">
                                 <h3>Anti-Xeno Academy</h3>
@@ -210,7 +226,6 @@
                         <div id="priorities" class="flex-row gap-medium">
                         </div>
                     </div>
-                    
                 </section>
                 <section class="about smallround grow">
                     <div class="max-text">


### PR DESCRIPTION
Adds a folder for the frontline debriefs, as well as the page for the first debrief.
For now, the page is only accessible by direct link or from the homepage, but I intend to add a new news page soon (see #30 )

I am currently considering changing the name, as Sirruf pointed out it is similar to the ingame Frontline Solutions.